### PR TITLE
Playing with generators

### DIFF
--- a/api/internal/utils/annotations.go
+++ b/api/internal/utils/annotations.go
@@ -4,14 +4,15 @@ import "sigs.k8s.io/kustomize/api/konfig"
 
 const (
 	// build annotations
-	BuildAnnotationPreviousKinds      = konfig.ConfigAnnoDomain + "/previousKinds"
-	BuildAnnotationPreviousNames      = konfig.ConfigAnnoDomain + "/previousNames"
-	BuildAnnotationPrefixes           = konfig.ConfigAnnoDomain + "/prefixes"
-	BuildAnnotationSuffixes           = konfig.ConfigAnnoDomain + "/suffixes"
-	BuildAnnotationPreviousNamespaces = konfig.ConfigAnnoDomain + "/previousNamespaces"
-	BuildAnnotationsRefBy             = konfig.ConfigAnnoDomain + "/refBy"
-	BuildAnnotationsGenBehavior       = konfig.ConfigAnnoDomain + "/generatorBehavior"
-	BuildAnnotationsGenAddHashSuffix  = konfig.ConfigAnnoDomain + "/needsHashSuffix"
+	BuildAnnotationPreviousKinds       = konfig.ConfigAnnoDomain + "/previousKinds"
+	BuildAnnotationPreviousNames       = konfig.ConfigAnnoDomain + "/previousNames"
+	BuildAnnotationPrefixes            = konfig.ConfigAnnoDomain + "/prefixes"
+	BuildAnnotationSuffixes            = konfig.ConfigAnnoDomain + "/suffixes"
+	BuildAnnotationPreviousNamespaces  = konfig.ConfigAnnoDomain + "/previousNamespaces"
+	BuildAnnotationsRefBy              = konfig.ConfigAnnoDomain + "/refBy"
+	BuildAnnotationsGenBehavior        = konfig.ConfigAnnoDomain + "/generatorBehavior"
+	BuildAnnotationsGenAddHashSuffix   = konfig.ConfigAnnoDomain + "/needsHashSuffix"
+	BuildAnnotationsGenDataTypeMapping = konfig.ConfigAnnoDomain + "/genDataTypeMapping"
 
 	// the following are only for patches, to specify whether they can change names
 	// and kinds of their targets

--- a/api/resource/factory.go
+++ b/api/resource/factory.go
@@ -77,6 +77,10 @@ func (rf *Factory) makeOne(rn *yaml.RNode, o *types.GeneratorArgs) *Resource {
 		if o.Options == nil || !o.Options.DisableNameSuffixHash {
 			resource.EnableHashSuffix()
 		}
+
+		if o.Options != nil && o.Options.DataTypeMapping != nil {
+			resource.SetDataTypeMapping(o.Options.DataTypeMapping)
+		}
 		resource.SetBehavior(types.NewGenerationBehavior(o.Behavior))
 	}
 

--- a/api/types/generatoroptions.go
+++ b/api/types/generatoroptions.go
@@ -18,6 +18,9 @@ type GeneratorOptions struct {
 
 	// Immutable if true add to all generated resources.
 	Immutable bool `json:"immutable,omitempty" yaml:"immutable,omitempty"`
+
+	// DataTypeMapping holds mapping between data keys and their string-represented data types
+	DataTypeMapping map[string]string `json:"dataTypeMapping,omitempty" yaml:"dataTypeMapping,omitempty"`
 }
 
 // MergeGlobalOptionsIntoLocal merges two instances of GeneratorOptions.
@@ -48,6 +51,7 @@ func MergeGlobalOptionsIntoLocal(
 	if globalOpts.Immutable {
 		localOpts.Immutable = true
 	}
+
 	return localOpts
 }
 


### PR DESCRIPTION
## Description

1. `configMapGenerator.[*].options.dataTypeMapping` mapps ConfigMap `.data` keys to specific data type carried by the value strings,
2. this map gets transformed into build annotations `internal.config.kubernetes.io/genDataTypeMapping=key=type,...`
3. if set on resource, it's being respected upon merging keys and an attempt is made to apply new value as a JSON Merge Patch,
4. on error, it falls back to the normal `merge` behavior, so returning new string as a expected value.

### Base

```yaml
# kustomization.yaml
apiVersion: kustomize.config.k8s.io/v1beta1
configMapGenerator:
  - files:
    - values=config.yaml
    name: test
    namespace: default
    options:
      disableNameSuffixHash: true
      dataTypeMapping:
        values: yaml
generatorOptions:
  disableNameSuffixHash: true
kind: Kustomization
```

```yaml
# config.yaml
configuration:
  key1: value1
  key2:
    nestedKey1: value11
    nestedKey2: value12
```

Base contain `option.dataTypeMapping` telling `values` key contains YAML.

### Overlay

```yaml
apiVersion: kustomize.config.k8s.io/v1beta1
configMapGenerator:
  - files:
    - values=config.yaml
    name: test
    behavior: merge
    namespace: default
    options:
      disableNameSuffixHash: true
kind: Kustomization
resources:
  - ../../bases/
```

```yaml
# config.yaml
configuration:
  key2:
    nestedKey1: newValue11
```

### Normal `merge` behavior

```yaml
# resultant config.yaml
apiVersion: v1
data:
  values: |
    configuration:
      key2:
        nestedKey1: newValue11
kind: ConfigMap
metadata:
  name: test
  namespace: default
```

### With type mapping, an attempt will be made to merge values

```yaml
# resultant config.yaml
apiVersion: v1
data:
  values: |
    configuration:
      key1: value1
      key2:
        nestedKey1: newValue11
        nestedKey2: value12
kind: ConfigMap
metadata:
  name: test
  namespace: default
```